### PR TITLE
Update hl7-mllp-connector-release-notes-mule-4.adoc

### DIFF
--- a/modules/ROOT/pages/connector/hl7-mllp-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/hl7-mllp-connector-release-notes-mule-4.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-*June 2018*
+*September 2018*
 
 _Premium_
 
@@ -17,15 +17,15 @@ xref:connectors::hl7/hl7-mllp-connector.adoc[HL7 MLLP Connector Guide]
 
 === Compatibility
 
-[width="100%", cols=",", options="header"]
+[%header%autowidth.spread]
 |===
 |Software |Version
-|Mule Runtime |4.0.0
+|Mule Runtime |4.0.0 and later
 |===
 
 === Fixed in this Release
 
- ACK like messages weren't flowing back to sender.
+ACK like messages weren't flowing back to sender.
 
 == 2.0.0
 

--- a/modules/ROOT/pages/connector/hl7-mllp-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/hl7-mllp-connector-release-notes-mule-4.adoc
@@ -25,7 +25,7 @@ xref:connectors::hl7/hl7-mllp-connector.adoc[HL7 MLLP Connector Guide]
 
 === Fixed in this Release
 
- ACK like messages weren't flowing back to sender. Fixed now :)
+ ACK like messages weren't flowing back to sender.
 
 == 2.0.0
 

--- a/modules/ROOT/pages/connector/hl7-mllp-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/hl7-mllp-connector-release-notes-mule-4.adoc
@@ -11,6 +11,22 @@ The Mule HL7 MLLP connector provides connectivity and parsing functionality for 
 
 xref:connectors::hl7/hl7-mllp-connector.adoc[HL7 MLLP Connector Guide]
 
+== 2.0.1
+
+*September 20, 2018*
+
+=== Compatibility
+
+[width="100%", cols=",", options="header"]
+|===
+|Software |Version
+|Mule Runtime |4.0.0
+|===
+
+=== Fixed in this Release
+
+ ACK like messages weren't flowing back to sender. Fixed now :)
+
 == 2.0.0
 
 *June 18, 2018*


### PR DESCRIPTION
HC-281: Certify and release HL7 MLLP 2.0.1 (Mule 4)