### PR TITLE
Update mongodb-connector-release-notes-mule-4.adoc

### DIFF
--- a/modules/ROOT/pages/connector/mongodb-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/mongodb-connector-release-notes-mule-4.adoc
@@ -12,12 +12,12 @@ Mule supports MongoDB integration by using the MongoDB Java Driver.
 
 == 5.3.0
 
-*September X, 2018*
+*September 27, 2018*
 
 === New Features
 
-* Added Triggers for *new*, *modified* and *deleted* Objects.
-These triggers allow you to execute a flow every time a new Object is created, or an existing Object is modified or deleted.
+* Added Triggers for *new*, *modified*, and *deleted* Objects.
+These triggers allow you to execute a flow each time a new Object is created, or when an existing Object is modified or deleted.
 
 == 5.2.0
 

--- a/modules/ROOT/pages/connector/mongodb-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/mongodb-connector-release-notes-mule-4.adoc
@@ -10,6 +10,15 @@ _Select_
 
 Mule supports MongoDB integration by using the MongoDB Java Driver.
 
+== 5.3.0
+
+*September X, 2018*
+
+=== New Features
+
+* Added Triggers for *new*, *modified* and *deleted* Objects.
+These triggers allow you to execute a flow every time a new Object is created, or an existing Object is modified or deleted.
+
 == 5.2.0
 
 *September 4, 2018*

--- a/modules/ROOT/pages/connector/mongodb-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/mongodb-connector-release-notes-mule-4.adoc
@@ -12,7 +12,16 @@ Mule supports MongoDB integration by using the MongoDB Java Driver.
 
 == 5.3.0
 
-*September 27, 2018*
+*September 26, 2018*
+
+=== Compatibility
+
+[%header%autowidth.spread]
+|===
+|Software|Version
+|Mule Runtime|4.0.0 and later
+|MongoDB| 3.0 to 3.2
+|===
 
 === New Features
 
@@ -39,7 +48,8 @@ This command is supplied as a parameter in the form of a MongoDB document.
 
 [source,text,linenums]
 ----
-2018-06-28T18:07:06.764+0000 I NETWORK  [conn262] Error receiving request from client: SSLHandshakeFailed: SSLHandshakeFailed. Ending connection from ...
+2018-06-28T18:07:06.764+0000 I NETWORK  [conn262] Error receiving request from client: 
+SSLHandshakeFailed: SSLHandshakeFailed. Ending connection from ...
 ----
 
 Now it is working.
@@ -58,7 +68,7 @@ This is a minor release that includes one new feature.
 
 *November 18, 2017*
 
-[%header]
+[%header%autowidth.spread]
 |===
 |Software|Version
 |Mule Runtime|4.0.0 and later
@@ -72,8 +82,8 @@ This is a minor release that includes one new feature.
 * Added feature for autocomplete the Collection Name field in operations.
 * Added metadata for Documents and Files.
 
-=== See Also
+== See Also
 
 * http://mongodb.github.io/mongo-java-driver/[MongoDB Java Driver]
 * https://forums.mulesoft.com[MuleSoft Forum]
-* https://support.mulesoft.com[Contact MuleSoft Support]
+* https://support.mulesoft.com/s/knowledge[Knowledge Base Articles]


### PR DESCRIPTION
MCN-213: [Mule 4] Release MongoDB v5.3.0 - Update Release Notes