### PR TITLE
Update ms-service-bus-connector-release-notes-mule-4.adoc

### DIFF
--- a/modules/ROOT/pages/connector/ms-service-bus-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/ms-service-bus-connector-release-notes-mule-4.adoc
@@ -29,7 +29,7 @@ _Select_
 
 * Automatic completion of queue and topic names, subscriptions, and rules may not work in Design Center.
 * In Design Center, the Live View feature does not work for most operations. In addition to this, the application log may be flooded with several "Could not serialize object" errors.
-* The connector leaks connections while publishing a message to a topic.
+* The connector leaks connections while publishing a message to a topic (Default caching strategy). As a workaround, configure the connector to use no caching strategy
 
 == See Also
 

--- a/modules/ROOT/pages/connector/ms-service-bus-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/ms-service-bus-connector-release-notes-mule-4.adoc
@@ -29,7 +29,7 @@ _Select_
 
 * Automatic completion of queue and topic names, subscriptions, and rules may not work in Design Center.
 * In Design Center, the Live View feature does not work for most operations. In addition to this, the application log may be flooded with several "Could not serialize object" errors.
-* The connector leaks connections while publishing a message to a topic (Default caching strategy). As a workaround, configure the connector to use no caching strategy
+* The connector leaks connections while publishing a message to a topic using the default caching strategy. As a workaround, configure the connector to disable the caching strategy.
 
 == See Also
 


### PR DESCRIPTION
SE-9360: Microsoft Azure Service Bus Connector leak connections