### PR TITLE
Update ibm-ctg-connector-release-notes-mule-4.adoc

### DIFF
--- a/modules/ROOT/pages/connector/ibm-ctg-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/ibm-ctg-connector-release-notes-mule-4.adoc
@@ -11,7 +11,7 @@ _Premium_
 The IBM CICS Transaction Gateway (IBM CTG) connector provides integration with back-end CICS applications using the CICS Transaction Gateway. For Java platforms, CTG implements the JCA resource adapter to connect Java applications to the CICS system.
 The connector serves as a handrail between Mule applications and the CTG.
 
-== 1.0.2
+== 2.0.0
 
 *January 19, 2018*
 


### PR DESCRIPTION
Version for Mule 4 was incorrect