### PR TITLE
Added release docs for Nov 3 release

### DIFF
--- a/modules/ROOT/pages/api-manager/api-manager-release-notes.adoc
+++ b/modules/ROOT/pages/api-manager/api-manager-release-notes.adoc
@@ -16,6 +16,15 @@ Anypoint Platform supports the following browsers:
 * Chrome (latest version)
 * Internet Explorer 11 and newer
 
+== 2.2.6
+
+*November 3, 2018*
+
+This release provides this new feature:
+
+*  Configure, secure & deploy HTTPs proxies using certificates (keystore/truststore) stored in Secrets Manager. This feature will be available for Mule 4 APIs deployed to CloudHub & Hybrid deployment targets. 
+
+
 == 2.2.5
 
 *August 30, 2018*


### PR DESCRIPTION
*  Configure, secure & deploy HTTPs proxies using certificates (keystore/truststore) stored in Secrets Manager. This feature will be available for Mule 4 APIs deployed to CloudHub & Hybrid deployment targets.