### PR TITLE
Added the change made in SE-6524

### DIFF
--- a/modules/ROOT/pages/runtime-manager-agent/runtime-manager-agent-1.11.0-release-notes.adoc
+++ b/modules/ROOT/pages/runtime-manager-agent/runtime-manager-agent-1.11.0-release-notes.adoc
@@ -22,6 +22,7 @@ This release contains the following issue fixes:
 * Displays the correct VM Vendor installed in the Mule Runtime in Runtime Manager
 * Returns the correct status response and message when trying to deploy an application with errors.
 * Upgrade version of several dependency libraries.
+* Changed default Agent truststore name from truststore.jks to anypoint-truststore.jks to avoid conflicts with application defined trust stores. 
 
 == Known Limitations and Workarounds
 


### PR DESCRIPTION
As per https://www.mulesoft.org/jira/browse/SE-6524 the default truststore was renamed from truststore.jks to anypoint-truststore.jks to avoid conflicts with application defined trust stores in this release, this is not noted in the current release notes