### PR TITLE
Update ibm-ctg-connector-release-notes-mule-4.adoc

### DIFF
--- a/modules/ROOT/pages/connector/ibm-ctg-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/ibm-ctg-connector-release-notes-mule-4.adoc
@@ -4,12 +4,31 @@ include::_attributes.adoc[]
 endif::[]
 :keywords: release notes, ibm ctg, cics, jca, connector
 
-*January 2018*
+*November 2018*
 
 _Premium_
 
 The IBM CICS Transaction Gateway (IBM CTG) connector provides integration with back-end CICS applications using the CICS Transaction Gateway. For Java platforms, CTG implements the JCA resource adapter to connect Java applications to the CICS system.
 The connector serves as a handrail between Mule applications and the CTG.
+
+== 2.1.1
+
+*November 29, 2018*
+
+=== Compatibility
+
+[%header%autowidth.spread]
+|===
+|Software |Version
+|Mule Runtime |4.0 and later
+|Java |8
+|IBM CICS TG (for Multiplatforms and for z/OS) |9.1 and 9.2
+|IBM CICS TG SDK |9.1 and 9.2
+|===
+
+=== Features
+
+* Added support for Multiple Containers, which are named references to a storage area managed by CICS that can hold any form of application data.
 
 == 2.0.0
 

--- a/modules/ROOT/pages/connector/ibm-ctg-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/ibm-ctg-connector-release-notes-mule-4.adoc
@@ -2,14 +2,13 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
-:keywords: release notes, ibm ctg, cics, jca, connector
 
 *November 2018*
 
 _Premium_
 
-The IBM CICS Transaction Gateway (IBM CTG) connector provides integration with back-end CICS applications using the CICS Transaction Gateway. For Java platforms, CTG implements the JCA resource adapter to connect Java applications to the CICS system.
-The connector serves as a handrail between Mule applications and the CTG.
+The IBM CICS Transaction Gateway (IBM CTG) connector provides integration with backend CICS applications using the CICS Transaction Gateway. For Java platforms, CTG implements the JCA resource adapter to connect Java applications to the CICS system.
+This connector provides connectivity between Mule applications and the CTG.
 
 == 2.1.1
 


### PR DESCRIPTION
IBM CTG 2.1.1