### PR TITLE
Docs 3569 monitoring 128 release notes

### DIFF
--- a/modules/ROOT/pages/monitoring/anypoint-monitoring-release-notes.adoc
+++ b/modules/ROOT/pages/monitoring/anypoint-monitoring-release-notes.adoc
@@ -5,6 +5,22 @@ endif::[]
 
 This document describes any new features and enhancements, known limitations, issues, and fixes in Anypoint Monitoring.
 
+== December 8 Release
+
+=== New Features
+
+* *Log Points* - (Requires Titanium subscription) You can generate logs for a running API without writing any code or redeploying your application. You can select specific parameters within the API for which to generate logs, for example, the request header host parameter. For more information about log points, see xref:/monitoring/log-points.adoc[Anypoint Monitoring Log Points]
+* *Flow Pinpoint Map* - (Requires Titanium subscription) You can now monitor the performance for connectors. For more information about monitoring connectors, see xref:/monitoring/monitor-connectors.adoc[Monitor Connectors]
+* *API Analytics* -
+
+
+=== Known Issues
+
+The Anypoint Monitoring log points feature is only supported on Mule runtime version 3.8.5 or later. For APIs not running on Mule runtime 3.8.5 or later, the log points feature does not appear for the API.
+
+Since you can't select the runtime version when you deploy an API from API Manager, you need to navigate to Runtime Manager, select the runtime version (3.8.5 or later), then redeploy the API.
+
+
 == Version 1.05
 
 === New Features and Enhancements

--- a/modules/ROOT/pages/monitoring/anypoint-monitoring-release-notes.adoc
+++ b/modules/ROOT/pages/monitoring/anypoint-monitoring-release-notes.adoc
@@ -11,14 +11,18 @@ This document describes any new features and enhancements, known limitations, is
 
 * *Log Points* - (Requires Titanium subscription) You can generate logs for a running API without writing any code or redeploying your application. You can select specific parameters within the API for which to generate logs, for example, the request header host parameter. For more information about log points, see xref:/monitoring/log-points.adoc[Anypoint Monitoring Log Points]
 * *Flow Pinpoint Map* - (Requires Titanium subscription) You can now monitor the performance for connectors. For more information about monitoring connectors, see xref:/monitoring/monitor-connectors.adoc[Monitor Connectors]
-* *API Analytics* -
+* *API Analytics* - API Analytics is now available in Anypoint Monitoring. See xref:/monitoring/
 
 
 === Known Issues
 
-The Anypoint Monitoring log points feature is only supported on Mule runtime version 3.8.5 or later. For APIs not running on Mule runtime 3.8.5 or later, the log points feature does not appear for the API.
+The Anypoint Monitoring log points feature is only supported on Anypoint runtime version 3.8.5 or later. For APIs not running on Anypoint runtime 3.8.5 or later, the log points feature does not appear for the API.
 
 Since you can't select the runtime version when you deploy an API from API Manager, you need to navigate to Runtime Manager, select the runtime version (3.8.5 or later), then redeploy the API.
+
+=== Fixed Issues
+
+* General bug fixes.
 
 
 == Version 1.05

--- a/modules/ROOT/pages/monitoring/anypoint-monitoring-release-notes.adoc
+++ b/modules/ROOT/pages/monitoring/anypoint-monitoring-release-notes.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 This document describes any new features and enhancements, known limitations, issues, and fixes in Anypoint Monitoring.
 
-== December 8 Release
+== Version 2.1
 
 === New Features
 


### PR DESCRIPTION
I don't know if we should put the version, and if we should I don't know if 2.1 is the right version to put. It almost seems like, since Anypoint Monitoring is not a versioned product, a date would be more useful. 