### PR TITLE
Adding 2.9.0 Runtime Manager missing fix to release notes

### DIFF
--- a/modules/ROOT/pages/runtime-manager/runtime-manager-2.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/runtime-manager/runtime-manager-2.9.0-release-notes.adoc
@@ -22,6 +22,7 @@ This release contains no feature changes.
 == Fixed Issues
 
 * The issue where properties supplied through the UI were not propagated during restart of the application is fixed.
+* Unable to pull application properties from Sandbox: `Target <<ServerID>> does not exist in your organization` is fixed.
 
 == Known Limitations and Workarounds
 


### PR DESCRIPTION
This change was previously approved but due to a confusion it was removed from the previous PR. Adding it back since the fix was released to prod on 8-Dec.