### PR TITLE
Changing the date on the release notes for API Designer 2.4.0

### DIFF
--- a/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
+++ b/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
@@ -13,7 +13,7 @@ These release notes cover the following versions of these features:
 * <<2-2-5,2.2.5>>
 
 == 2.4.0
-*January 12, 2019*
+*January 10, 2019*
 
 This release contains an enhancement and fixes a number of issues.
 


### PR DESCRIPTION
The release date was yesterday. I used January 10 in two other topics for this release, so I need to change the date to that in this topic, too.