### PR TITLE
truststore.jks name changed in agent 1.9.x

### DIFF
--- a/modules/ROOT/pages/mule-runtime/updating-mule-versions.adoc
+++ b/modules/ROOT/pages/mule-runtime/updating-mule-versions.adoc
@@ -84,7 +84,7 @@ To migrate your Mule servers on-premises that are being managed through Runtime 
 . Copy the following three files from the path `<MULE_HOME>/conf` from your old Mule installation into the same on the new installation:
 * `mule-agent.yml`
 * `mule-agent.jks`
-* `truststore.jks`
+* `truststore.jks` and/or `anypoint-truststore.jks`
 . Copy the mule-agent-plugin folder from the path `<MULE_HOME>/plugins` from your old Mule installation into the same on the new installation.
 . Open a terminal window and navigate to the `<MULE_HOME>/bin` of your new Mule installation. Once there, run the following command:
 +


### PR DESCRIPTION
the truststore change the name to anypoint-truststore.jks in agent version 1.9.x