### PR TITLE
Changing the release notes to mention that the toggle switch appears for projects created before 1/10/19

### DIFF
--- a/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
+++ b/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
@@ -20,7 +20,7 @@ This release includes enhancements and fixes a number of issues.
 
 === Enhancements
 
-* You can turn on or off the stricter validation that began with the 2.4.0 release on January 10, 2019. You might want to do so to work with in an API-specification project that was created before this date, but don't yet have plans for resolving the messages that this validation displays.
+* *For projects created before January 10, 2019:* You can turn on or off the stricter validation that began with the 2.4.0 release on January 10, 2019. You might want to do so to work with in an API-specification project that was created before this date, but don't yet have plans for resolving the messages that this validation displays.
 +
 To turn this validation off, toggle the switch that is labeled *Show Strict Errors* in the top-right corner of the editor. The default is On.
 + Even if you toggle this validation off, the grace period in which you must resolve the messages is still in effect. The grace period lasts at least until January 10, 2020.


### PR DESCRIPTION
I've added this mention because the Support team and customers are confused by not seeing the toggle switch for all of their projects.