### PR TITLE
Update ldap-connector-release-notes-mule-4.adoc

### DIFF
--- a/modules/ROOT/pages/connector/ldap-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/ldap-connector-release-notes-mule-4.adoc
@@ -66,33 +66,6 @@ The LDAP Connector is compatible with:
 
 * The connector now has 2 triggers one for new objects and one for modified objects. Using these 2 triggers one can receive notifications if ldap entries are created or updated since the app was started or since a configured timestamp that can be specified when configuring the trigger.
 
-== 3.0.0
-
-*November 18, 2017*
-
-Release notes for version 3.0.0 of the LDAP connector.
-
-=== Compatibility
-
-The LDAP Connector is compatible with:
-
-[%header%autowidth.spread]
-|===
-|Application/Service|Version
-|Mule Runtime|4.0.0 and later
-|Java|1.8
-|===
-
-=== Features
-
-* The LDAP connector is built with the new Anypoint SDK (also known as the Extensions Framework) v1.0.0-rc-SNAPSHOT.
-
-=== Fixed in this Release
-
-* Fixed an exception when member ranges were used along schemaEnabled.
-  Note: Member ranges are feature specific to the Active Directory.
-* Added support for custom trust store through Extended configuration parameters.
-
 == See Also
 
 * https://forums.mulesoft.com[MuleSoft Forum]


### PR DESCRIPTION
LDAP Connector 3.0.0 was removed from Exchange