### PR TITLE
Update salesforce-connector-release-notes-mule-4.adoc

### DIFF
--- a/modules/ROOT/pages/connector/salesforce-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/salesforce-connector-release-notes-mule-4.adoc
@@ -517,24 +517,6 @@ or an opportunity object, you now have an easier way to initiate a flow.
 
 * Query with parameters didn't work.
 
-== 9.0.0
-
-*November 3, 2017*
-
-Mule 4 update.
-
-=== Compatibility
-
-Salesforce connector version 9.0.0 is compatible with:
-
-[%header%autowidth.spread]
-|===
-|Application/Service |Version
-|Mule Runtime |Mule Enterprise Edition 4.0.0 and later
-|Anypoint Studio |7.0.0 and later
-|Salesforce |v37.0, v38.0, v39.0, v40.0
-|===
-
 == See Also
 
 * xref:connectors::salesforce/salesforce-connector.adoc[Salesforce Connector Guide]


### PR DESCRIPTION
Salesforce Connector 9.0.0 was removed from Exchange