### PR TITLE
Release notes for API Designer 2.4.4

### DIFF
--- a/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
+++ b/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
@@ -22,7 +22,8 @@ These release notes cover the following versions of these features:
 === Fixed Issues
 // SE-11152
 * When you are working on an API fragment, the editor now no longer displays the switch to turn on the mocking service.
-
+// SE-11095
+* When the documentation displayed in the *Documentation* pane contains more lines than the pane can accommodate, the pane does not display a scrollbar. Therefore, it is not possible to see all of the documentation.
 
 == 2.4.3
 *February 23, 2019*

--- a/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
+++ b/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
@@ -24,6 +24,10 @@ These release notes cover the following versions of these features:
 * When you are working on an API fragment, the editor now no longer displays the switch to turn on the mocking service.
 // SE-11095
 * When the documentation displayed in the *Documentation* pane contains more lines than the pane can accommodate, the pane does not display a scrollbar. Therefore, it is not possible to see all of the documentation.
+// SE-10926
+* Properties that are defined as numbers in the body of an API appear as strings in the API console.
+
+
 
 == 2.4.3
 *February 23, 2019*

--- a/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
+++ b/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
@@ -28,7 +28,8 @@ These release notes cover the following versions of these features:
 * Properties that are defined as numbers in the body of an API appear as strings in the API console.
 // SE-10879
 * The mocking service might return a response in JSON, even though the specification defined responses to be in XML.
-
+// SE-9582
+* The mocking service responded with a `400 Bad Request` error if a RAML API specification defined a JSON type for an HTTP header.
 
 == 2.4.3
 *February 23, 2019*

--- a/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
+++ b/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
@@ -26,7 +26,8 @@ These release notes cover the following versions of these features:
 * When the documentation displayed in the *Documentation* pane contains more lines than the pane can accommodate, the pane does not display a scrollbar. Therefore, it is not possible to see all of the documentation.
 // SE-10926
 * Properties that are defined as numbers in the body of an API appear as strings in the API console.
-
+// SE-10879
+* The mocking service might return a response in JSON, even though the specification defined responses to be in XML.
 
 
 == 2.4.3

--- a/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
+++ b/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
@@ -5,6 +5,7 @@ endif::[]
 
 These release notes cover the following versions of these features:
 
+* <<2-4-4,2.4.4>>
 * <<2-4-3,2.4.3>>
 * <<2-4-2,2.4.2>>
 * <<2-4-1,2.4.1>>
@@ -14,6 +15,14 @@ These release notes cover the following versions of these features:
 * <<2-2-7,2.2.7>>
 * <<2-2-6,2.2.6>>
 * <<2-2-5,2.2.5>>
+
+== 2.4.4
+*March 23, 2019*
+
+=== Fixed Issues
+// SE-11152
+* When you are working on an API fragment, the editor now no longer displays the switch to turn on the mocking service.
+
 
 == 2.4.3
 *February 23, 2019*

--- a/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
+++ b/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
@@ -31,7 +31,7 @@ These release notes cover the following versions of these features:
 // SE-9582
 * The mocking service responded with a `400 Bad Request` error if a RAML API specification defined a JSON type for an HTTP header.
 // SE-10974
-* The editor did not display an error message is a NamedExample fragment contained properties that the RAML specification does not allow.
+* The editor did not display an error message when a NamedExample fragment contained properties that the RAML specification does not allow.
 
 == 2.4.3
 *February 23, 2019*

--- a/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
+++ b/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
@@ -30,6 +30,8 @@ These release notes cover the following versions of these features:
 * The mocking service might return a response in JSON, even though the specification defined responses to be in XML.
 // SE-9582
 * The mocking service responded with a `400 Bad Request` error if a RAML API specification defined a JSON type for an HTTP header.
+// SE-10974
+* The editor did not display an error message is a NamedExample fragment contained properties that the RAML specification does not allow.
 
 == 2.4.3
 *February 23, 2019*


### PR DESCRIPTION
I wrote up the SE tickets only. The other tickets in the filter were labeled as development bugs.