### PR TITLE
Update salesforce-connector-release-notes-mule-4.adoc

### DIFF
--- a/modules/ROOT/pages/connector/salesforce-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/salesforce-connector-release-notes-mule-4.adoc
@@ -30,8 +30,10 @@ To change an existing connection type to the new features, change the XML for th
 |salesforce:oauth-jwt-connection | salesforce:cached-oauth-jwt-connection
 |salesforce:oauth-saml-connection | salesforce:cached-oauth-saml-connection
 |salesforce:oauth-user-pass-connection | salesforce:cached-oauth-user-pass-connection
-|salesforce:config-with-oauth-connection | None: Removed in v9.6
+|salesforce:config-with-oauth-connection | No change
 |===
++
+IMPORTANT: The OAuth 2.0 connection type is marked as Deprecated in Studio and Design Center, however OAuth 2.0 is still available. The "Deprecated" label was accidentally added and can be ignored.
 +
 The previous values are available but are deprecated. We recommend moving to the new versions.
 

--- a/modules/ROOT/pages/connector/salesforce-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/salesforce-connector-release-notes-mule-4.adoc
@@ -33,7 +33,7 @@ To change an existing connection type to the new features, change the XML for th
 |salesforce:config-with-oauth-connection | No change
 |===
 +
-IMPORTANT: The OAuth 2.0 connection type is marked as Deprecated in Studio and Design Center, however OAuth 2.0 is still available. The "Deprecated" label was accidentally added and can be ignored.
+IMPORTANT: The OAuth 2.0 connection type is marked as Deprecated in Studio and Design Center, however OAuth 2.0 is still available. The "Deprecated" label can be ignored.
 +
 The previous values are available but are deprecated. We recommend moving to the new versions.
 

--- a/modules/ROOT/pages/connector/salesforce-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/salesforce-connector-release-notes-mule-4.adoc
@@ -33,7 +33,7 @@ To change an existing connection type to the new features, change the XML for th
 |salesforce:config-with-oauth-connection | No change
 |===
 +
-IMPORTANT: The OAuth 2.0 connection type is marked as Deprecated in Studio and Design Center, however OAuth 2.0 is still available. The "Deprecated" label can be ignored.
+IMPORTANT: The OAuth 2.0 connection type is marked as Deprecated in Studio and Design Center, however OAuth 2.0 is still available. The OAuth 2.0 "(Deprecated)" label can be ignored.
 +
 The previous values are available but are deprecated. We recommend moving to the new versions.
 


### PR DESCRIPTION
https://www.mulesoft.org/jira/browse/DOCS-4462 -- Explains how the OAuth 2.0 connection type was accidentally marked by the devs as Deprecated when it wasn't.