### PR TITLE
CloudHub spacing typo

### DIFF
--- a/modules/ROOT/pages/cloudhub/cloudhub-runtimes-release-notes.adoc
+++ b/modules/ROOT/pages/cloudhub/cloudhub-runtimes-release-notes.adoc
@@ -10,9 +10,9 @@ These are the release notes for patches which are made to the Mule runtimes on C
 
 3.9.2 Runtime Update:	
 
- * Both Visualizer and Monitoring functionality are now controlled through the Anypoint Monitoring UI. After you upgrade to this runtime, your apps no longer appear in Visualizer. The apps are still there, but you need to re-enable Visualizer functionality in the Anypoint Monitoring *Settings* to see them. 
- 
- For more information, see xref:visualizer::setup.adoc#_set_up_for_standalone_mule[Set up Anypoint Visualizer].
+ * Both Visualizer and Monitoring functionality are now controlled through the Anypoint Monitoring UI. After you upgrade to this runtime, your apps no longer appear in Visualizer. The apps are still there, but you need to re-enable Visualizer functionality in the Anypoint Monitoring *Settings* to see them.
+
+For more information, see xref:visualizer::setup.adoc#_set_up_for_standalone_mule[Set up Anypoint Visualizer].
 
 == March 26, 2019
 


### PR DESCRIPTION
CloudHub spacing typo at https://docs.mulesoft.com/release-notes/cloudhub/cloudhub-runtimes-release-notes