### PR TITLE
Update amazon-s3-connector-release-notes.adoc

### DIFF
--- a/modules/ROOT/pages/connector/amazon-s3-connector-release-notes.adoc
+++ b/modules/ROOT/pages/connector/amazon-s3-connector-release-notes.adoc
@@ -33,9 +33,7 @@ The Amazon S3 connector is compatible with:
 
 === Fixed in this Release
 
-* Refactored AWS and S3 Connector.
-* Refactored client configuration and moved common params to CommonConfig.
-* Fixed conflict with net.javacrumbs.json-unit library.
+* Fixed conflict with net.javacrumbs.json-unit library. (SE-9670)
 * Corrected icons for theme.light.
 
 == 4.2.0

--- a/modules/ROOT/pages/connector/amazon-s3-connector-release-notes.adoc
+++ b/modules/ROOT/pages/connector/amazon-s3-connector-release-notes.adoc
@@ -14,7 +14,7 @@ Starting with v.4.0.0, the S3 Connector is licensed commercially with Anypoint P
 
 == Version 4.3.0 
 
-*Date to be determined.*
+*April 9, 2019*
 
 === Compatibility
 
@@ -33,8 +33,8 @@ The Amazon S3 connector is compatible with:
 
 === Fixed in this Release
 
-* Fixed conflict with net.javacrumbs.json-unit library. (SE-9670)
-* Corrected icons for theme.light.
+* Fixed conflict with `net.javacrumbs.json-unit` library. (SE-9670)
+* Corrected icons for`theme.light`.
 
 == 4.2.0
 


### PR DESCRIPTION
- removed unnecessary items from "Fixed in this release"
- added missing SE number to "Fixed conflict with net.javacrumbs.json-unit library."