### PR TITLE
Release notes for APID 2.4.6

### DIFF
--- a/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
+++ b/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
@@ -27,6 +27,8 @@ These release notes cover the following versions of these features:
 * Specifications that were several MB in size could not be published to Exchange.
 // SE-10917
 * Resource types and traits in API specifications that were written in RAML 1.0 were not being validated.
+// SE-11123
+* A project might never finish loading if you created the project in the visual API editor, created a data type in that project, closed the project, and then attempted to reopen the project.
 
 
 == 2.4.5

--- a/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
+++ b/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
@@ -5,6 +5,7 @@ endif::[]
 
 These release notes cover the following versions of these features:
 
+* <<2-4-6,2.4.6>>
 * <<2-4-5,2.4.5>>
 * <<2-4-4,2.4.4>>
 * <<2-4-3,2.4.3>>
@@ -16,6 +17,15 @@ These release notes cover the following versions of these features:
 * <<2-2-7,2.2.7>>
 * <<2-2-6,2.2.6>>
 * <<2-2-5,2.2.5>>
+
+== 2.4.6
+*April 20, 2019*
+
+
+=== Fixed Issues
+// SE-10861
+* Specifications that were several MB in size could not be published to Exchange.
+
 
 == 2.4.5
 *April 6, 2019*

--- a/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
+++ b/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
@@ -22,9 +22,11 @@ These release notes cover the following versions of these features:
 *April 20, 2019*
 
 
-=== New Feature
+=== New Features
 
-Import projects directly from Exchange. You no longer have to download a project from Exchange to your computer or other location, and then import it into a new project in API Designer. See xref:design-center::design-import-files.adoc[Import Files into an API Project] for the steps.
+* You can now import projects directly from Exchange. You no longer have to download a project from Exchange to your computer or other location, and then import it into a new project in API Designer. See xref:design-center::design-import-files.adoc[Import Files into an API Project] for the steps.
+* If you define a global media type in a specification in the visual API editor, you no longer are required to select a media type when you define the body of a response for a method. Instead, you can now leave the option `default` specified. This option is available only if a global media type is defined.
+
 
 === Fixed Issues
 // SE-10861

--- a/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
+++ b/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
@@ -31,7 +31,7 @@ This release includes two new features and several fixes.
 
 === Fixed Issues
 // SE-10861
-* Specifications that were several MB in size could not be published to Exchange.
+* Specifications that were several MB in size could not be published to Exchange. Now, for both the importing of projects from Exchange and the publishing projects to Exchange, the .zip files are reduced in size, preventing such errors.
 // SE-10917
 * Resource types and traits in API specifications that were written in RAML 1.0 were not being validated.
 // SE-11123

--- a/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
+++ b/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
@@ -25,6 +25,8 @@ These release notes cover the following versions of these features:
 === Fixed Issues
 // SE-10861
 * Specifications that were several MB in size could not be published to Exchange.
+// SE-10917
+* Resource types and traits in API specifications that were written in RAML 1.0 were not being validated.
 
 
 == 2.4.5

--- a/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
+++ b/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
@@ -31,7 +31,8 @@ These release notes cover the following versions of these features:
 * A project might never finish loading if you created the project in the visual API editor, created a data type in that project, closed the project, and then attempted to reopen the project.
 // SE-11193
 * The API editor returned the error message `Recursive type at (_x_, _y_)` for recursive DataType definitions.
-
+// SE-11374
+* The mocking service would fail if an API specification used the `example` facet, rather than the `examples` facet, to include a NamedExample fragment.
 
 == 2.4.5
 *April 6, 2019*

--- a/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
+++ b/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
@@ -22,6 +22,10 @@ These release notes cover the following versions of these features:
 *April 20, 2019*
 
 
+=== New Feature
+
+Import projects directly from Exchange. You no longer have to download a project from Exchange to your computer or other location, and then import it into a new project in API Designer. See xref:design-center::design-import-files.adoc[Import Files into an API Project] for the steps.
+
 === Fixed Issues
 // SE-10861
 * Specifications that were several MB in size could not be published to Exchange.

--- a/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
+++ b/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
@@ -29,6 +29,8 @@ These release notes cover the following versions of these features:
 * Resource types and traits in API specifications that were written in RAML 1.0 were not being validated.
 // SE-11123
 * A project might never finish loading if you created the project in the visual API editor, created a data type in that project, closed the project, and then attempted to reopen the project.
+// SE-11193
+* The API editor returned the error message `Recursive type at (_x_, _y_)` for recursive DataType definitions.
 
 
 == 2.4.5

--- a/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
+++ b/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
@@ -33,6 +33,8 @@ These release notes cover the following versions of these features:
 * The API editor returned the error message `Recursive type at (_x_, _y_)` for recursive DataType definitions.
 // SE-11374
 * The mocking service would fail if an API specification used the `example` facet, rather than the `examples` facet, to include a NamedExample fragment.
+// SE-11175
+*  The API console might display all examples for all methods that were in a specification, not just the examples for the selected method.
 
 == 2.4.5
 *April 6, 2019*

--- a/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
+++ b/modules/ROOT/pages/design-center/design-center-release-notes-api_specs.adoc
@@ -21,6 +21,7 @@ These release notes cover the following versions of these features:
 == 2.4.6
 *April 20, 2019*
 
+This release includes two new features and several fixes.
 
 === New Features
 


### PR DESCRIPTION
I'm including the SE tickets and the new features, not the production defects.

Also, I'm not writing up the production defects for the mocking service. Production defects don't go into release notes.