### PR TITLE
Update x12-edi-connector-release-notes-mule-4.adoc

### DIFF
--- a/modules/ROOT/pages/connector/x12-edi-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/x12-edi-connector-release-notes-mule-4.adoc
@@ -3,11 +3,8 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-*May 2019*
 
-_Premium_
-
-xref:connectors::x12-edi/x12-edi-connector.adoc[X12 EDI Connector Guide]
+Support Category: Premium
 
 
 == 2.1.0
@@ -16,17 +13,17 @@ xref:connectors::x12-edi/x12-edi-connector.adoc[X12 EDI Connector Guide]
 
 === Features
 
-* Adds support for user-supplied values for control segments (controlled by `useSuppliedValues` configuration parameter).
+* Added support for user-supplied values for control segments. These are controlled by the `useSuppliedValues` configuration parameter.
 
 === Fixed in this Release
 
-* Make sure data not passed out of parser for transaction set with fatal error (SE-11384)
-* Implement lock sharing for tracking identifier numbers in ObjectStore with multiple CloudHub workers (SE-11308)
-* Allow multiple HIPAA transaction sets in group (SE-9043)
-* Correct issues found with metadata representation.
-* Fix logging to follow Mule conventions.
-* Update to latest dependency versions to avoid security issues.
-* Correct errors in schemas for 005010X222A1 and 005010X224A2.
+* The transaction set parser was passing data with a fatal error. This is fixed. (SE-11384)
+* Implemented lock sharing for tracking identifier numbers in the ObjectStore connector with multiple CloudHub workers. (SE-11308)
+* Multiple HIPAA transaction sets are now allowed in a group. (SE-9043)
+* Corrected issues found with metadata representation.
+* Logging now follows Mule conventions.
+* Updated to latest dependency versions in order to prevent security issues.
+* Corrected errors in schemas for 005010X222A1 and 005010X224A2.
 
 === Compatibility
 

--- a/modules/ROOT/pages/connector/x12-edi-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/x12-edi-connector-release-notes-mule-4.adoc
@@ -17,13 +17,13 @@ Support Category: Premium
 
 === Fixed in this Release
 
-* The transaction set parser was passing data with a fatal error. This is fixed. (SE-11384)
+* Was passing out data for bad transaction sets in the output of the reader. (SE-11384)
 * Implemented lock sharing for tracking identifier numbers in the ObjectStore connector with multiple CloudHub workers. (SE-11308)
 * Multiple HIPAA transaction sets are now allowed in a group. (SE-9043)
 * Corrected issues found with metadata representation.
-* Logging now follows Mule conventions.
-* Updated to latest dependency versions in order to prevent security issues.
-* Corrected errors in schemas for 005010X222A1 and 005010X224A2.
+* Logging didn't follow Mule conventions.
+* Updated to latest dependency versions.
+* Schemas 005010X222A1 and 005010X224A2 contained errors.
 
 === Compatibility
 

--- a/modules/ROOT/pages/connector/x12-edi-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/x12-edi-connector-release-notes-mule-4.adoc
@@ -3,11 +3,43 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-*August 2018*
+*May 2019*
 
 _Premium_
 
 xref:connectors::x12-edi/x12-edi-connector.adoc[X12 EDI Connector Guide]
+
+
+== 2.1.0
+
+*May 10, 2019*
+
+=== Features
+
+* Adds support for user-supplied values for control segments (controlled by `useSuppliedValues` configuration parameter).
+
+=== Fixed in this Release
+
+* Make sure data not passed out of parser for transaction set with fatal error (SE-11384)
+* Implement lock sharing for tracking identifier numbers in ObjectStore with multiple CloudHub workers (SE-11308)
+* Allow multiple HIPAA transaction sets in group (SE-9043)
+* Correct issues found with metadata representation.
+* Fix logging to follow Mule conventions.
+* Update to latest dependency versions to avoid security issues.
+* Correct errors in schemas for 005010X222A1 and 005010X224A2.
+
+=== Compatibility
+
+X12 EDI Connector v2.0.0 is compatible with the following:
+
+[%header,cols="30a,70a"]
+|===
+|Application/Service |Version
+|Mule Runtime |4.1.0 and later
+|Anypoint Studio |7.1.0 and later
+|X12 |003010, 003020, 003030, 003040, 003050, 003060, 003070, 004010, 004020, 004030, 004040, 004050, 004060, 005010, 005020, 005030, 005040, 005050, and 006020
+|HIPAA |005010X212, 005010X214B3, 005010X217, 005010X218, 005010X220A1, 005010X221A1, 005010X222A1, 005010X222A2, 005010X223A2, 005010X223A3, 005010X224A2, 005010X224A3, and 005010X279A1
+|===
 
 == 2.0.1
 


### PR DESCRIPTION
Updates for X12 EDI Connector 2.1.0 release.