### PR TITLE
IBM CTG 2.2.0 -- ready for release

### DIFF
--- a/modules/ROOT/pages/connector/ibm-ctg-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/ibm-ctg-connector-release-notes-mule-4.adoc
@@ -7,11 +7,9 @@ Support Category: Premium
 
 The IBM CICS Transaction Gateway (IBM CTG) connector provides integration with backend CICS applications using the CICS Transaction Gateway. For Java platforms, CTG implements the JCA resource adapter to connect Java applications to the CICS system. This connector provides connectivity between Mule applications and the CTG.
 
-////
-
 == 2.2.0
 
-*May 27, 2019*
+*May 29, 2019*
 
 === Compatibility
 
@@ -27,8 +25,6 @@ The IBM CICS Transaction Gateway (IBM CTG) connector provides integration with b
 === Features
 
 * `Pooling profile` was enabled for connections.
-
-////
 
 == 2.1.1
 


### PR DESCRIPTION
Uncommented the section for the 2.2.0 release and set the release date to May 29, 2019. 
Covered by DOCS-5090