### PR TITLE
DOCS-5271 Exchange: 2019-06-19 updates

### DIFF
--- a/modules/ROOT/pages/exchange/anypoint-exchange-release-notes.adoc
+++ b/modules/ROOT/pages/exchange/anypoint-exchange-release-notes.adoc
@@ -3,6 +3,26 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
+== June 2019
+
+=== New Features
+
+* Simplified interface by removing links when they are not applicable. (EXC-3759)
+* When users do not have permission to view a dependent asset, the asset is not clickable. (EXC-3607)
+* Exchange offers three scopes, which show all assets, all assets in the master organization, or all assets in the current business group. When a user has selected the business group scope and selects a new business group, Exchange previously changed to the master organization scope, and now stays at the business group scope. (EXC-3430)
+* When users search with clickable categories and tags, Exchange now shows assets from all business groups by default. Users can still filter these results by business group. (EXC-3219)
+* When users reach the rate limit for an API, a message appears explaining this. (EXC-2991)
+
+=== Fixed in this Release
+
+* Images uploaded after May 31st, 2019 now render correctly on the MuleSoft public portal. (EXC-3793)
+* Users can view images on custom pages in a public portal in all cases. (EXC-3669)
+* Category names can include the slash and backslash characters (`/` and `\`). Users are now able to delete category names containing these characters. (EXC-3662)
+* Users editing one page can discard those changes and create a second page. (EXC-3642)
+* Improved error message for attempts to use Maven to publish a new version of a REST API created in Exchange, since REST APIs are not one of the asset types Maven can publish. (EXC-3511)
+* Users uploading a file can change the asset type without uploading the file again. Exchange re-validates the file. (EXC-3503)
+* Users can view the full RAML or OAS code in public Exchange portals in all cases. (EXC-3254)
+
 == May 2019
 
 === New Features

--- a/modules/ROOT/pages/exchange/anypoint-exchange-release-notes.adoc
+++ b/modules/ROOT/pages/exchange/anypoint-exchange-release-notes.adoc
@@ -7,11 +7,11 @@ endif::[]
 
 === New Features
 
-* Simplified interface by removing links when they are not applicable. (EXC-3759)
-* When users do not have permission to view a dependent asset, the asset is not clickable. (EXC-3607)
-* Exchange offers three scopes, which show all assets, all assets in the master organization, or all assets in the current business group. When a user has selected the business group scope and selects a new business group, Exchange previously changed to the master organization scope, and now stays at the business group scope. (EXC-3430)
-* When users search with clickable categories and tags, Exchange now shows assets from all business groups by default. Users can still filter these results by business group. (EXC-3219)
-* When users reach the rate limit for an API, a message appears explaining this. (EXC-2991)
+* Simplify interface by showing only applicable links. (EXC-3759)
+* Prevent permissions errors by making only viewable assets clickable. (EXC-3607)
+* A user viewing assets by business group who selects a different business group sees the new group and not the master organization. (EXC-3430)
+* A user who clicks a category or tag sees matching assets from all business groups. (EXC-3219)
+* Notify users who reach the rate limit for an API. (EXC-2991)
 
 === Fixed in this Release
 

--- a/modules/ROOT/pages/exchange/anypoint-exchange-release-notes.adoc
+++ b/modules/ROOT/pages/exchange/anypoint-exchange-release-notes.adoc
@@ -7,20 +7,19 @@ endif::[]
 
 === New Features
 
-* Simplify interface by showing only applicable links. (EXC-3759)
-* Prevent permissions errors by making only viewable assets clickable. (EXC-3607)
+* Simplify interface by showing only applicable links in Studio experience. (EXC-3759)
+* Prevent permissions errors by making only viewable assets clickable in the asset dependencies table. (EXC-3607)
 * A user viewing assets by business group who selects a different business group sees the new group and not the master organization. (EXC-3430)
-* A user who clicks a category or tag sees matching assets from all business groups. (EXC-3219)
+* A user who clicks a category or tag sees matching assets from all business groups and assets provided by Mulesoft. (EXC-3219)
 * Notify users who reach the rate limit for an API. (EXC-2991)
 
 === Fixed in this Release
 
 * Images uploaded after May 31st, 2019 now render correctly on the MuleSoft public portal. (EXC-3793)
 * Users can view images on custom pages in a public portal in all cases. (EXC-3669)
-* Category names can include the slash and backslash characters (`/` and `\`). Users are now able to delete category names containing these characters. (EXC-3662)
 * Users editing one page can discard those changes and create a second page. (EXC-3642)
-* Improved error message for attempts to use Maven to publish a new version of a REST API created in Exchange, since REST APIs are not one of the asset types Maven can publish. (EXC-3511)
-* Users uploading a file can change the asset type without uploading the file again. Exchange re-validates the file. (EXC-3503)
+* Improved error message for attempts to use Maven to publish a new version of a REST API created in Exchange with a different asset type, since asset type cannot be changed. (EXC-3511)
+* Users uploading a file when creating a new asset can change the asset type without uploading the file again. Exchange re-validates the file. (EXC-3503)
 * Users can view the full RAML or OAS code in public Exchange portals in all cases. (EXC-3254)
 
 == May 2019


### PR DESCRIPTION
Exchange updates that have not yet been deployed:
```
Features:
* Users editing text can set heading levels consistently in both visual and markdown mode. (EXC-3643)
Fixes:
* Category names can include the slash and backslash characters (`/` and `\`). Users are now able to delete category names containing these characters. (EXC-3662)
* Users can update and delete reviews and see the changes immediately on all version pages. (EXC-3022)
* Users can now import and install the SSH Connector in Anypoint Studio 6 from Exchange. (EXC-3014)
```