### PR TITLE
Secure Configuration Properties compatibility

### DIFF
--- a/modules/ROOT/pages/policies/client-id-enforcement-release-notes.adoc
+++ b/modules/ROOT/pages/policies/client-id-enforcement-release-notes.adoc
@@ -8,6 +8,9 @@ endif::[]
 
 *Apr 26, 2019*
 
+=== Module version compatibility
+*Secure Configuration Properties 1.1.0*
+
 === Minimum Mule Version
 
 *Mule 4.1.0*


### PR DESCRIPTION
This version of the policy seems to be incompatible with older Secure Configuration Properties module versions.
This lack of version compatibility has caused some problems to our customers
https://na101.salesforce.com/5002T000019SJFb?srPos=0&srKp=500
linked a support case showing a customer needing advice on this