### PR TITLE
Update runtime-fabric-release-notes.adoc

### DIFF
--- a/modules/ROOT/pages/runtime-fabric/runtime-fabric-release-notes.adoc
+++ b/modules/ROOT/pages/runtime-fabric/runtime-fabric-release-notes.adoc
@@ -6,12 +6,13 @@ endif::[]
 
 In addition to these release notes, see the complete xref:1.0@runtime-fabric::index.adoc[Anypoint Runtime Fabric] documentation.
 
-== 1.3.27 - July 1, 2019
+== 1.3.28 - July 3, 2019
 
 This release includes the following fixes and enhancements:
 
+* Added: Runtime Fabric agent components will re-initialize if disconnected from control plane for more than six hours.
 * Fixed: Applications failed to deploy when using a certificate with an uppercase common name.
-* Updated: Deployments are now labeled with `rtf.mulesoft.com/id`
+* Updated: Deployments are now labeled with `rtf.mulesoft.com/id`.
 
 == 1.3.24 - June 17, 2019
 


### PR DESCRIPTION
`1.3.27` wasn't released in the end as we decided to wait for another fix