### PR TITLE
Clarified supported versions of SAP

### DIFF
--- a/modules/ROOT/pages/connector/sap-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/sap-connector-release-notes-mule-4.adoc
@@ -21,7 +21,7 @@ NOTE: This connector is not supported for use with Flow Designer in Design Cente
 |Mule Runtime|4.0.0 and later
 |Anypoint Studio|7.0 and later
 |Java|8
-|SAP Solution| ECC 6.0 and later
+|SAP Solution| SAP ECC 6.0 and it's subsequent enhancement packages
 |Supported Modules|SAP CRM, SAP ERP, SAP SRM, SAP SCM, and any other modules compatible with the NetWeaver platform.
 |===
 

--- a/modules/ROOT/pages/connector/sap-connector-release-notes-mule-4.adoc
+++ b/modules/ROOT/pages/connector/sap-connector-release-notes-mule-4.adoc
@@ -21,7 +21,7 @@ NOTE: This connector is not supported for use with Flow Designer in Design Cente
 |Mule Runtime|4.0.0 and later
 |Anypoint Studio|7.0 and later
 |Java|8
-|SAP Solution| SAP ECC 6.0 and it's subsequent enhancement packages
+|SAP Solution| SAP ECC 6.0 and its subsequent enhancement packages.
 |Supported Modules|SAP CRM, SAP ERP, SAP SRM, SAP SCM, and any other modules compatible with the NetWeaver platform.
 |===
 


### PR DESCRIPTION
Explicit clarification that the SAP connector only supports SAP ECC 6.0 and it's associated enhancements packages