### PR TITLE
Wrong studio version (typo error)

### DIFF
--- a/modules/ROOT/pages/studio/anypoint-studio-7.3-with-4.2-runtime-update-site-3-release-notes.adoc
+++ b/modules/ROOT/pages/studio/anypoint-studio-7.3-with-4.2-runtime-update-site-3-release-notes.adoc
@@ -34,7 +34,7 @@ Build Id:
 
 === Runtime Compatibility
 
-* Studio 7.3.4 is bundled with Mule Runtime Engine 4.2.0, however, you can use it with earlier Mule Runtime versions such as as 4.1.4.
+* Studio 7.3.3 is bundled with Mule Runtime Engine 4.2.0, however, you can use it with earlier Mule Runtime versions such as as 4.1.4.
 
 === Studio Compatibility
 


### PR DESCRIPTION
These release notes refer to Studio 7.3.3 and then it mentions 7.3.4 which hasn't been released by that time yet.